### PR TITLE
Fix Logging in RedirectHandler

### DIFF
--- a/bundles/SeoBundle/src/Redirect/RedirectHandler.php
+++ b/bundles/SeoBundle/src/Redirect/RedirectHandler.php
@@ -223,7 +223,7 @@ final class RedirectHandler
 
         $response->headers->set(self::RESPONSE_HEADER_NAME_ID, (string) $redirect->getId());
 
-        $this->redirectLogger->info(Tool::getAnonymizedClientIp(), ['Custom-Redirect ID: ' . $redirect->getId() . ', Source: ' . $_SERVER['REQUEST_URI'] . ' -> ' . $url]);
+        $this->redirectLogger->info(Tool::getAnonymizedClientIp() ?? 'Anonymous', ['Custom-Redirect ID: ' . $redirect->getId() . ', Source: ' . $_SERVER['REQUEST_URI'] . ' -> ' . $url]);
 
         return $response;
     }


### PR DESCRIPTION
`getAnonymizedClientIp` is allowed to return a null value, but the logger always requires a string as message. I've added "Anonymous" instead of null. This mostly happens in test scenarios where a request is not always available.